### PR TITLE
fix #66 and workaround for sourceforge failed downloads

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+2.4.2
+=====
+* workaround for sourceforge https://github.com/grke/burp/issues/865
+* fix permissions too permisive on /etc/burp #66
+
 2.4.1
 =====
 * Improve speed to synchronize files/incexc files improved around 5x (from 58s to 10s)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -47,11 +47,10 @@ download_dir: "{{ ansible_env.HOME }}/burp"
 
 burp_server_etc: '/etc/burp'
 ## Additional autoupgrade vars:
-# autoupgrade_url_win64: "https://sourceforge.net/projects/burp/files/burp-{{ autoupgrade_version }}/burp-win64-installer-{{ autoupgrade_version }}.exe/download"
-# autoupgrade_url_win32: "https://sourceforge.net/projects/burp/files/burp-{{ autoupgrade_version }}/burp-win32-installer-{{ autoupgrade_version }}.exe/download"
-# By default using direct mirror link because downloading from default sourceforge.net takes additional 6s to get the file:
-autoupgrade_url_win32: "https://managedway.dl.sourceforge.net/project/burp/burp-{{ autoupgrade_version }}/burp-win32-installer-{{ autoupgrade_version }}.exe"
-autoupgrade_url_win64: "https://managedway.dl.sourceforge.net/project/burp/burp-{{ autoupgrade_version }}/burp-win64-installer-{{ autoupgrade_version }}.exe"
+#autoupgrade_url_win64: "https://sourceforge.net/projects/burp/files/burp-{{ autoupgrade_version }}/burp-win64-installer-{{ autoupgrade_version }}.exe/download"
+#autoupgrade_url_win32: "https://sourceforge.net/projects/burp/files/burp-{{ autoupgrade_version }}/burp-win32-installer-{{ autoupgrade_version }}.exe/download"
+autoupgrade_url_win64: "https://github.com/pablodav/burp/releases/download/{{ autoupgrade_version }}/burp-win64-installer-{{ autoupgrade_version }}.exe"
+autoupgrade_url_win32: "https://github.com/pablodav/burp/releases/download/{{ autoupgrade_version }}/burp-win32-installer-{{ autoupgrade_version }}.exe"
 
 ### Burp Server
 ### http://burp.grke.org/docs/manpage.html

--- a/tasks/2_unprivileged_user.yml
+++ b/tasks/2_unprivileged_user.yml
@@ -11,11 +11,10 @@
     group: "{{ burp_sv_server_user }}"
     comment: Ansible managed burp-service service
 
-- name: unpriv_user | Ensure /etc dir has permissions
+- name: unpriv_user | Ensure etc dir has permissions
   file:
     path: "{{ burp_server_etc }}"
-    recurse: yes 
     state: directory
     owner: "{{ burp_sv_server_user }}"
     group: "{{ burp_sv_server_user }}"
-    mode: '0755'
+    mode: '0750'


### PR DESCRIPTION
closes #66

2.4.2
=====
* workaround for sourceforge https://github.com/grke/burp/issues/865
* fix permissions too permisive on /etc/burp #66
