### PR TITLE
Add support for custom client in the client's configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ burp2_add_manual_clients:
   - name: client_name
     profile: profile name to use (optional), default: profile_lnxsrv (these files are in incexc/ dir).
     password: client_password (optional), default: burp_client_password var
+    content: list of custom content (optional)
   - name: second_client
 ```
 

--- a/templates/profiles/new_client.j2
+++ b/templates/profiles/new_client.j2
@@ -2,6 +2,13 @@
 
 password = {{ item.password | default(burp_client_password) }}
 
+{% if item.content is defined -%}
+	{%- for l in item.content -%}
+	{{ l }}
+	{% endfor %}
+
+{% endif -%}
+
 # More configuration files can be read, using syntax like the following
 # (without the leading '# ').
 . incexc/{{ item.profile | default('profile_lnxsrv') }}


### PR DESCRIPTION
I added support for custom content in the client's configuration file. My use case was to be able to add a custom include to a client without having to define a new profile just for this addition. To use that feature, just add a `content` key when defining a client in `burp2_add_manual_clients`. The `content` key is of course optional, so this shouldn't break anything.

Example:
```yaml
burp2_add_manual_clients:
  - name: client_name
    profile: profile name to use (optional), default: profile_lnxsrv (these files are in incexc/ dir).
    password: client_password (optional), default: burp_client_password var
    content: 
      - 'include = E:/'
  - name: second_client
```