### PR TITLE
Fix an error when the role ansible-role-powertools doesn't exists and the role is not targeting a server running CentOS/RH

### DIFF
--- a/tasks/1_1_multi_os.yml
+++ b/tasks/1_1_multi_os.yml
@@ -12,5 +12,5 @@
     - "../vars/{{ ansible_os_family }}.yml"
     - "../vars/defaults.yml"
 
-- import_tasks: 1_2_redhat.yml
+- include_tasks: 1_2_redhat.yml
   when: ansible_os_family == "RedHat"


### PR DESCRIPTION
With `import_tasks`, ansible still evaluate the code and throws an error if the role doesn't exists. Replaced with `include_tasks` instead.

This fix this error :
```
TASK [Exécution du rôle coffeeitworks.ansible_burp2_server] ****************************************************************************************************************************
vendredi 20 janvier 2023  13:48:20 -0500 (0:00:01.831)       0:00:07.183 ****** 
vendredi 20 janvier 2023  13:48:20 -0500 (0:00:01.831)       0:00:07.182 ****** 
ERROR! the role 'ansible-role-powertools' was not found in /home/xxxx/git/conformite/playbooks/roles:/home/xxxx/git/conformite/roles:/home/xxxx/git/conformite/playbooks

The error appears to be in '/home/xxxx/git/conformite/roles/coffeeitworks.ansible_burp2_server/tasks/1_2_redhat.yml': line 24, column 11, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

  import_role:
    name: ansible-role-powertools
          ^ here
```