### PR TITLE
Fix path to notify_failure_script

### DIFF
--- a/templates/burp-server.conf.j2
+++ b/templates/burp-server.conf.j2
@@ -149,7 +149,7 @@ timer_arg = {{ timer_arg }}
 #notify_failure_arg = From: burp
 #notify_failure_arg = Subject: %b failed: %c %w
 {% if burp_notify_failure  %}
-notify_failure_script = /usr/share/burp/scripts/notify_script
+notify_failure_script = /usr/local/share/burp/scripts/notify_script
 notify_failure_arg = sendmail -t
 notify_failure_arg = To: {{ burp_notify_failure_email_to }}
 notify_failure_arg = From: {{ burp_notify_failure_email_from }}


### PR DESCRIPTION
When compiling burp, the install script is copying the script into `/usr/local/share/burp/scripts` (not `/usr/share/burp/scripts`)