### PR TITLE
Render logging of manual delete cron job optional

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,7 @@
 ### Modules ---
 # Configure Burp manual delete
 burp_manual_delete_enabled: true
+burp_manual_delete_logs: true
 # Configure Burp Autoupgrade
 burp_server_autoupgrade_enabled: true
 # Activate clients from git repository

--- a/tasks/7_1_manual_delete.yml
+++ b/tasks/7_1_manual_delete.yml
@@ -25,7 +25,7 @@
 - name: manual_delete | Cron task to delete files in burp trash
   cron:
     name: delete files in burp trash
-    job: 'rm -rfv {{ burp_trash  }}/* >> {% if burp_manual_delete_logs %}{{ burp_logs }}/manual_delete.log{% else %}/dev/null {% endif %}'
+    job: 'flock --exclusive {{ burp_trash  }} --command "rm -rfv {{ burp_trash  }}/*" >> {% if burp_manual_delete_logs %}{{ burp_logs }}/manual_delete.log{% else %}/dev/null {% endif %}'
     user: root
     cron_file: manual_delete
     minute: "{{ item.minute }}"

--- a/tasks/7_1_manual_delete.yml
+++ b/tasks/7_1_manual_delete.yml
@@ -25,7 +25,7 @@
 - name: manual_delete | Cron task to delete files in burp trash
   cron:
     name: delete files in burp trash
-    job: 'rm -rfv {{ burp_trash  }}/* >> {{ burp_logs }}/manual_delete.log'
+    job: 'rm -rfv {{ burp_trash  }}/* >> {% if burp_manual_delete_logs %}{{ burp_logs }}/manual_delete.log{% else %}/dev/null {% endif %}'
     user: root
     cron_file: manual_delete
     minute: "{{ item.minute }}"


### PR DESCRIPTION
I found that the manual_delete cron job is very verbose (something like 8 GB in 24h). I think this logging is not useful. I added a variable to render this logging optional.