### PR TITLE
Validate certs

### DIFF
--- a/tasks/3_build-burp.yml
+++ b/tasks/3_build-burp.yml
@@ -28,7 +28,6 @@
     url: "{{ burpurl }}"
     dest: "{{ download_dir }}/{{ burpsrc }}.{{ burpsrcext }}"
     timeout: 30
-    validate_certs: no
 
 - name: build-burp | Unpack Burp source files tar.gz
   shell: cd {{ download_dir }} && tar -xzvf {{ burpsrc }}.{{ burpsrcext }} creates={{ download_dir }}/{{ burpsrc }}

--- a/tasks/8_autoupgrade.yml
+++ b/tasks/8_autoupgrade.yml
@@ -29,7 +29,6 @@
     url: "{{ item.src }}"
     dest: "{{ item.dest }}"
     timeout: 30
-    validate_certs: no
     owner: "{{ burp_sv_server_user }}"
     group: "{{ burp_sv_server_user }}"
     # use_proxy: yes


### PR DESCRIPTION
I found two tasks where the role doesn't check ssl certificate. The certificates are valid, I didn't find a reason why not to check them.